### PR TITLE
Simplify formatNumber

### DIFF
--- a/cmd/scrap.go
+++ b/cmd/scrap.go
@@ -40,19 +40,7 @@ var scrapCmd = &cobra.Command{
 }
 
 func formatNumber(n int) string {
-	if n < 10 {
-		return fmt.Sprintf("000%d", n)
-	}
-
-	if n < 100 {
-		return fmt.Sprintf("00%d", n)
-	}
-
-	if n < 1000 {
-		return fmt.Sprintf("0%d", n)
-	}
-
-	return fmt.Sprintf("%d", n)
+	return fmt.Sprintf("%04d", n)
 }
 
 func scrapPlate(plate string, persist bool) {


### PR DESCRIPTION
Pad with leading zeros is supported by fmt.

Playground sample: https://play.golang.org/p/5zLmT2XTrlc